### PR TITLE
show icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,35 @@ const svgSprite = require('dat-icons')
 document.body.innerHTML += svgSprite()
 ```
 
-Make sure this is the first element after the `<body>` opening tag
+Make sure this is the first element after the `<body>` opening tag.
+
+Icons can later be referenced like so:
+
+```html
+<svg><use xlink:href="#daticon-happy-dat"></use></svg>
+```
+
+### Icon Names
+
+- `daticon-clipboard`
+- `daticon-create-new-dat`
+- `daticon-delete`
+- `daticon-download`
+- `daticon-edit-dat`
+- `daticon-file`
+- `daticon-folder`
+- `daticon-happy-dat`
+- `daticon-hexagon-outlines`
+- `daticon-import-dat`
+- `daticon-link`
+- `daticon-loading`
+- `daticon-lock`
+- `daticon-menu`
+- `daticon-open-in-desktop`
+- `daticon-open-in-finder`
+- `daticon-question`
+- `daticon-sad-dat`
+- `daticon-star-dat`
 
 ## Build
 

--- a/example.js
+++ b/example.js
@@ -1,2 +1,3 @@
 const svgSprite = require('./')
 document.body.innerHTML += svgSprite()
+document.body.innerHTML += '<svg><use xlink:href="#daticon-happy-dat"></use></svg>'


### PR DESCRIPTION
Hello!

I was unfamiliar with how SVG sprites work so I thought I'd look into it and add a little documentation. This PR adds a list showing all the icon names to the readme, and adds a `happy-dat` icon to the example script.

✨  [preview](https://github.com/ungoldman/dat-icons/blob/370530ad89b284bbf723f413d58040eb2b2dbcc0/README.md) ✨ 

I tried adding the SVGs to the readme but found out that github doesn't render SVGs because of [security concerns](https://github.com/isaacs/github/issues/316).
